### PR TITLE
CAR-2331 Fix broken paths for librtmp

### DIFF
--- a/aircore/CMakeLists.txt
+++ b/aircore/CMakeLists.txt
@@ -121,9 +121,8 @@ foreach(ARCH ${ARCHS})
   set(libx264_bin_dir "${libx264_bin_arch_dir}/${ARCH}")
 
   # run_config depends on librtmp because configure checks existence of librtmp.a using pkg-config
-  set(librtmp_src_dir "${at_media_deps_dir}/rtmpdump/librtmp")
-  set(librtmp_bin_arch_dir "${PROJECT_BINARY_DIR}/../rtmpdump/build")
-  set(librtmp_bin_dir "${librtmp_bin_arch_dir}/${ARCH}/lib")
+  set(librtmp_src_dir "${at_media_deps_dir}/rtmpdump/")
+  set(librtmp_bin_dir "${PROJECT_BINARY_DIR}/../rtmpdump")
 
   set(crypto_target $<TARGET_FILE:crypto>)
 

--- a/aircore/run_config.sh
+++ b/aircore/run_config.sh
@@ -97,7 +97,7 @@ export CFLAGS
 export LDFLAGS
 
 # Configure checks existence of libx264 and librtmp using pkg-config
-PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${LIBX264_LIB_DIR}:${LIBRTMP_LIB_DIR}/pkgconfig"
+PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${LIBX264_LIB_DIR}:${LIBRTMP_LIB_DIR}"
 # as well as libfreetype
 PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${LIBFREETYPE_LIB_DIR}"
 # as well as libharfbuzz


### PR DESCRIPTION
I updated `rtmpdump` to work better, since it was doing in-tree builds and such making it not behave well when building for multiple architectures in the same project. When I did this I had to modify some paths, and forgot to update these to the correct one. Without this fix, `ffmpeg` has issues finding `librtmp` with `pkg-config` during configure.