### PR TITLE
CAR-2524 Fix librtmp to have Release/Debug folder in Xcode build

### DIFF
--- a/aircore/CMakeLists.txt
+++ b/aircore/CMakeLists.txt
@@ -58,7 +58,7 @@ if (NOT libx264_empty)
   )
 endif()
 
-is_empty_dir("${at_deps_dir}/third_party/rtmpdump/rtmpdump" rtmpdump_empty)
+is_empty_dir("${at_media_deps_dir}/rtmpdump" rtmpdump_empty)
 if (NOT rtmpdump_empty)
   message("ffmpeg: enabling rtmpdump")
   set(ffmpeg_configure_flags
@@ -157,6 +157,7 @@ foreach(ARCH ${ARCHS})
          "${ffmpeg_configure_flags}"
          "${CMAKE_SHARED_LINKER_FLAGS}"
          "${YASM}"
+         "$<$<STREQUAL: ${CMAKE_GENERATOR}, Xcode>:$<IF:$<CONFIG:Release>,Release/,Debug/>>"
     WORKING_DIRECTORY ${ffmpeg_binary_dir}
     DEPENDS ${PROJECT_SOURCE_DIR}/run_config.sh ${last_configure_target}
     VERBATIM

--- a/aircore/run_config.sh
+++ b/aircore/run_config.sh
@@ -27,6 +27,7 @@ INSTALL_DIR="${22}"
 CONFIGURE_FLAGS="${23}"
 LDFLAGS="${24}"
 YASM="${25}"
+GENERATOR_SUFFIX="${26}"
 
 CONFIG_OPTS="\
 --disable-iconv \
@@ -57,6 +58,13 @@ echo "LIBRTMP_LIB_DIR: ${LIBRTMP_LIB_DIR}"
 echo "LIBCRYPTO_LIB_DIR: ${LIBCRYPTO_LIB_DIR}"
 echo "LIBSSL_LIB_DIR: ${LIBSSL_LIB_DIR}"
 echo "LIBDECREPIT_LIB_DIR: ${LIBDECREPIT_LIB_DIR}"
+echo "CUDA_INC_DIR: ${CUDA_INC_DIR}"
+echo "CUDA_LIB_DIR: ${CUDA_LIB_DIR}"
+echo "INSTALL_DIR: ${INSTALL_DIR}"
+echo "CONFIGURE_FLAGS: ${CONFIGURE_FLAGS}"
+echo "LDFLAGS: ${LDFLAGS}"
+echo "YASM: ${YASM}"
+echo "GENERATOR_SUFFIX: ${GENERATOR_SUFFIX}"
 
 if [ "$OS" = "android" ] ; then
   CONFIG_OPTS="${CONFIG_OPTS} --host=armv7"
@@ -97,7 +105,7 @@ export CFLAGS
 export LDFLAGS
 
 # Configure checks existence of libx264 and librtmp using pkg-config
-PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${LIBX264_LIB_DIR}:${LIBRTMP_LIB_DIR}"
+PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${LIBX264_LIB_DIR}:${LIBRTMP_LIB_DIR}/${GENERATOR_SUFFIX}"
 # as well as libfreetype
 PKG_CONFIG_PATH="${PKG_CONFIG_PATH}:${LIBFREETYPE_LIB_DIR}"
 # as well as libharfbuzz


### PR DESCRIPTION
Xcode builds need to have `Release` or `Debug` appended to the `PKG_CONFIG_PATH` var, so that it finds the configuration specific `pkg-config` file. 