### PR TITLE
CAR-2620 exclude xcode deployment target

### DIFF
--- a/aircore/CMakeLists.txt
+++ b/aircore/CMakeLists.txt
@@ -88,6 +88,24 @@ set(ffmpeg_binary_base_dir "${PROJECT_BINARY_DIR}/build")
 # serialize the calls to configure by chaining dependencies since configuring
 # multiple archs in parallel seems to cause issues (at least with Xcode)
 set(last_configure_target "")
+set(FFMPEG_APPLE_ENV_CLEANUP_ARGS "")
+if (OSX)
+  set(FFMPEG_APPLE_ENV_CLEANUP_ARGS
+    --unset=DRIVERKIT_DEPLOYMENT_TARGET
+    --unset=IPHONEOS_DEPLOYMENT_TARGET
+    --unset=TVOS_DEPLOYMENT_TARGET
+    --unset=WATCHOS_DEPLOYMENT_TARGET
+    --unset=XROS_DEPLOYMENT_TARGET
+  )
+elseif (IOS)
+  set(FFMPEG_APPLE_ENV_CLEANUP_ARGS
+    --unset=DRIVERKIT_DEPLOYMENT_TARGET
+    --unset=MACOSX_DEPLOYMENT_TARGET
+    --unset=TVOS_DEPLOYMENT_TARGET
+    --unset=WATCHOS_DEPLOYMENT_TARGET
+    --unset=XROS_DEPLOYMENT_TARGET
+  )
+endif()
 
 foreach(ARCH ${ARCHS})
   set(ffmpeg_binary_dir "${ffmpeg_binary_base_dir}/${ARCH}")
@@ -151,8 +169,8 @@ foreach(ARCH ${ARCHS})
   file(GLOB_RECURSE ffmpeg_sources src *.c *.h *.s)
   add_custom_command(
     OUTPUT ${libavcodec_arch_file} ${libavformat_arch_file} ${libavutil_arch_file} ${libswscale_arch_file} ${libswresample_arch_file} ${libavfilter_arch_file}
-    COMMAND make V=1 # add V=1 for verbose output
-    COMMAND make install-headers
+    COMMAND ${CMAKE_COMMAND} -E env ${FFMPEG_APPLE_ENV_CLEANUP_ARGS} make V=1 # add V=1 for verbose output
+    COMMAND ${CMAKE_COMMAND} -E env ${FFMPEG_APPLE_ENV_CLEANUP_ARGS} make install-headers
     DEPENDS ffmpeg_configure_${ARCH} ${ffmpeg_sources}
     WORKING_DIRECTORY ${ffmpeg_binary_dir}
   )

--- a/aircore/run_config.sh
+++ b/aircore/run_config.sh
@@ -25,6 +25,23 @@ LDFLAGS="${20}"
 YASM="${21}"
 GENERATOR_SUFFIX="${22}"
 
+# Xcode script phases export deployment targets for every Apple platform in the
+# project. ffmpeg configure invokes clang directly, so clear the unrelated
+# platform targets before probing the selected SDK.
+if [ "$OS" = osx ] ; then
+  unset DRIVERKIT_DEPLOYMENT_TARGET
+  unset IPHONEOS_DEPLOYMENT_TARGET
+  unset TVOS_DEPLOYMENT_TARGET
+  unset WATCHOS_DEPLOYMENT_TARGET
+  unset XROS_DEPLOYMENT_TARGET
+elif [ "$OS" = ios ] ; then
+  unset DRIVERKIT_DEPLOYMENT_TARGET
+  unset MACOSX_DEPLOYMENT_TARGET
+  unset TVOS_DEPLOYMENT_TARGET
+  unset WATCHOS_DEPLOYMENT_TARGET
+  unset XROS_DEPLOYMENT_TARGET
+fi
+
 CONFIG_OPTS="\
 --disable-iconv \
 --disable-bzlib \


### PR DESCRIPTION
https://airtime.atlassian.net/browse/CAR-2620
Clear unrelated Apple deployment target variables beforex ffmpeg configure and make steps run clang from Xcode script phases. same change we made for libvpx